### PR TITLE
Cpp compat

### DIFF
--- a/jitcon.mod
+++ b/jitcon.mod
@@ -50,13 +50,9 @@ VERBATIM
 
 #ifdef NRN_VERSION_GTEQ_8_2_0
 #define Vect IvocVect
-externc Object* ivoc_list_item(Object*, int); // should be part of API
 
 #if NRN_VERSION_EQ(8, 2, 0)
     // should be part of API
-    extern Symbol *hoc_get_symbol(const char*);
-    extern Vect* vector_arg(int);
-    extern double mcell_ran4(uint32_t*, double*, unsigned int, double);
     extern void clear_event_queue();
 #endif // == 8.2.0
 

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -80,11 +80,11 @@ extern void clear_event_queue();
 extern Objectdata *hoc_objectdata;
 extern int nrn_mlh_gsort();
 extern int cmpdfn();
-extern unsigned int *scrset();
 
 // Prototypes from other mod files in this project
 extern int list_vector_px3 (Object *ob, int i, double** px, void** vv);
 extern double *vector_newsize(Vect*, int);
+extern unsigned int *scrset(int);
 
 // forward jitcon prototypes
 int gsort2(double *db, Point_process **da ,int dvt ,double *dbs, Point_process **das);
@@ -578,6 +578,7 @@ static double* lop (Object *ob, unsigned int i) {
 
 // use stoppo() as a convenient conditional breakpoint in gdb (gdb watching is too slow)
 int stoppo () {
+  return 0;
 }
 ENDVERBATIM
 

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -50,16 +50,8 @@ VERBATIM
 
 #ifdef NRN_VERSION_GTEQ_8_2_0
 #define Vect IvocVect
-
-#if NRN_VERSION_EQ(8, 2, 0)
-    // should be part of API
-    extern void clear_event_queue();
-#endif // == 8.2.0
-
 #else //  < 8.2.0
-
 #define Vect void
-
 // Prototypes from NEURON API
 extern Vect* vector_arg(int);
 extern double hoc_call_func(Symbol*, int narg);

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -43,6 +43,7 @@ VERBATIM
 #include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <math.h>
 #include <limits.h> /* contains LONG_MAX */
 
@@ -63,7 +64,7 @@ extern Object* ivoc_list_item(Object*, int);
 extern Symbol *hoc_get_symbol();
 extern Symbol *hoc_lookup();
 extern Point_process* ob2pntproc(Object*);
-extern double mcell_ran4();
+extern double mcell_ran4(uint32_t*, double*, unsigned int, double);
 extern int hoc_is_double_arg(int narg);
 static void hxe() { hoc_execerror("",0); }
 #if defined(t)
@@ -281,7 +282,7 @@ PROCEDURE jitcon (tm) {
 PROCEDURE callback (fl) {
   VERBATIM {
   int ii,jj; double idty, del; double weed, prid, prty, poid, poty, w;
-  unsigned int valseed;
+  uint32_t valseed;
   ii=(unsigned int)((-_lfl)-1); // -1,-2,-3 -> 0,1,2
   ip=IDP;
   idty=(double)(FOFFSET+ip->id)+0.1*(double)ip->type+0.01;
@@ -307,7 +308,7 @@ PROCEDURE callback (fl) {
     weed=prty*allcells+poty*100+prid*10+poid;
     // vw1.setrnd(4,2*0.01*w,weed) vw.add(0.99*w) // from (bsticknet.hoc_32:235)
     valseed=(unsigned int)weed; w=WMAT((int)prty,(int)poty);
-    mcell_ran4(&valseed, &wts, 1, 2*0.01*w); // generate 1 value
+    mcell_ran4(&valseed, wts, 1, 2*0.01*w); // generate 1 value
     // printf("%g %g %g %g %g\n",w,wts[0],weed,prid,poid);
     wts[0]+=0.99*w; // note that weight is created presynaptically rather than postsynaptically
                     // as in intf.mod

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -175,7 +175,7 @@ CONSTRUCTOR {
     if (ifarg(1)) { lid=(int) *getarg(1); } else { lid= UINT_MAX; }
     if (ifarg(2)) { lty=(int) *getarg(2); } else { lty= -1; }
     if (ifarg(3)) { lco=(int) *getarg(3); } else { lco= -1; }
-    _p_sop = (void*)ecalloc(1, sizeof(id0)); // important that calloc sets all flags etc to 0
+    IDP = (id0*)ecalloc(1, sizeof(id0)); // important that calloc sets all flags etc to 0
     ip = IDP;
     ip->id=lid; ip->type=lty; ip->col=lco; ip->pg=0x0; ip->dvi=0x0; ip->sprob=0x0;
     ip->jcn = 0;
@@ -469,6 +469,7 @@ int gsort2 (double *db, Point_process **da,int dvt,double *dbs, Point_process **
     dbs[i]=db[scr[i]];
     das[i]=da[scr[i]];
   }
+  return 0;
 }
 ENDVERBATIM
 

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -78,8 +78,9 @@ extern short *nrn_artcell_qindex_;
 extern double nrn_event_queue_stats(double*);
 extern void clear_event_queue();
 extern Objectdata *hoc_objectdata;
-extern int nrn_mlh_gsort();
-extern int cmpdfn();
+typedef int (*doubleComparator)(double, double);
+extern int nrn_mlh_gsort(double*, int*, int, doubleComparator);
+extern int cmpdfn(double, double);
 
 // Prototypes from other mod files in this project
 extern int list_vector_px3 (Object *ob, int i, double** px, void** vv);
@@ -464,7 +465,7 @@ int gsort2 (double *db, Point_process **da,int dvt,double *dbs, Point_process **
   unsigned int *scr, i;
   scr=scrset(dvt);
   for (i=0;i<dvt;i++) scr[i]=i;
-  nrn_mlh_gsort(db, scr, dvt, cmpdfn);
+  nrn_mlh_gsort(db, (int*)scr, dvt, cmpdfn);
   for (i=0;i<dvt;i++) {
     dbs[i]=db[scr[i]];
     das[i]=da[scr[i]];

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -47,31 +47,35 @@ VERBATIM
 #include <math.h>
 #include <limits.h> /* contains LONG_MAX */
 
-#ifdef NRN_VERSION_GTEQ_8_2_0 
+#ifdef NRN_VERSION_GTEQ_8_2_0
 #define Vect IvocVect
-#else
+extern Object* ivoc_list_item(Object*, int); // should be part of API
+
+#if NRN_VERSION_EQ(8, 2, 0)
+    // should be part of API
+    extern Symbol *hoc_get_symbol(const char*);
+    extern Vect* vector_arg(int);
+    extern double mcell_ran4(uint32_t*, double*, unsigned int, double);
+    extern void clear_event_queue();
+#endif // == 8.2.0
+
+#else //  < 8.2.0
+
 #define Vect void
-#endif
 
 // Prototypes from NEURON API
-extern void* vector_arg();
+extern Vect* vector_arg(int);
 extern double hoc_call_func(Symbol*, int narg);
-extern double* hoc_pgetarg();
+extern double* hoc_pgetarg(int);
 extern FILE* hoc_obj_file_arg(int narg);
-extern Object** hoc_objgetarg();
+extern Object** hoc_objgetarg(int);
 extern int ivoc_list_count(Object*);
 extern Object* ivoc_list_item(Object*, int);
-extern Symbol *hoc_get_symbol();
-extern Symbol *hoc_lookup();
+extern Symbol *hoc_get_symbol(const char*);
+extern Symbol *hoc_lookup(const char*);
 extern Point_process* ob2pntproc(Object*);
 extern double mcell_ran4(uint32_t*, double*, unsigned int, double);
 extern int hoc_is_double_arg(int narg);
-static void hxe() { hoc_execerror("",0); }
-#if defined(t)
-static void initmodel();
-#else
-static initmodel();
-#endif
 extern int stoprun;
 extern double hoc_epsilon;
 extern short *nrn_artcell_qindex_;
@@ -80,15 +84,24 @@ extern void clear_event_queue();
 extern Objectdata *hoc_objectdata;
 typedef int (*doubleComparator)(double, double);
 extern int nrn_mlh_gsort(double*, int*, int, doubleComparator);
-extern int cmpdfn(double, double);
+
+#endif // not NRN_VERSION_GTEQ_8_2_0
 
 // Prototypes from other mod files in this project
 extern int list_vector_px3 (Object *ob, int i, double** px, void** vv);
 extern double *vector_newsize(Vect*, int);
 extern unsigned int *scrset(int);
+extern int cmpdfn(double, double);
 
 // forward jitcon prototypes
 int gsort2(double *db, Point_process **da ,int dvt ,double *dbs, Point_process **das);
+static void hxe() { hoc_execerror("",0); }
+
+#if defined(t)
+static void initmodel();
+#else
+static initmodel();
+#endif
 
 #define CTYN 2  // number of cell types being used
 #define PI 3.141592653589793115997963468544

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -46,6 +46,12 @@ VERBATIM
 #include <math.h>
 #include <limits.h> /* contains LONG_MAX */
 
+#ifdef NRN_VERSION_GTEQ_8_2_0 
+#define Vect IvocVect
+#else
+#define Vect void
+#endif
+
 // Prototypes from NEURON API
 extern void* vector_arg();
 extern double hoc_call_func(Symbol*, int narg);
@@ -70,7 +76,6 @@ extern double hoc_epsilon;
 extern short *nrn_artcell_qindex_;
 extern double nrn_event_queue_stats(double*);
 extern void clear_event_queue();
-extern double *vector_newsize();
 extern Objectdata *hoc_objectdata;
 extern int nrn_mlh_gsort();
 extern int cmpdfn();
@@ -78,6 +83,7 @@ extern unsigned int *scrset();
 
 // Prototypes from other mod files in this project
 extern int list_vector_px3 (Object *ob, int i, double** px, void** vv);
+extern double *vector_newsize(Vect*, int);
 
 // forward jitcon prototypes
 int gsort2(double *db, Point_process **da ,int dvt ,double *dbs, Point_process **das);
@@ -219,7 +225,7 @@ NET_RECEIVE (w) { LOCAL tmp,jcn
 PROCEDURE jitcon (tm) {
   VERBATIM {
   double mindel, randel, idty, *x; int prty, poty, i, j, k, dv, dvt; 
-  Point_process *pnt; void* voi;
+  Point_process *pnt; Vect* voi;
   // qsz = nrn_event_queue_stats(stt);
   // if (qsz>=qlimit) { printf("qlimit %g exceeded at t=%g\n",qlimit,t); qlimit*=2; }
   ip=IDP;
@@ -363,7 +369,7 @@ FUNCTION getdvi () {
   VERBATIM 
   {
   int j,dvt; double *dbs, *x;
-  void* voi; Point_process **das;
+  Vect* voi; Point_process **das;
   ip=IDP; ip->pg=pg; // this should be called right after jitcondiv()
   dvt=ip->dvt;
   dbs=ip->del;   das=ip->dvi;

--- a/jitcon.mod
+++ b/jitcon.mod
@@ -46,10 +46,11 @@ VERBATIM
 #include <stdint.h>
 #include <math.h>
 #include <limits.h> /* contains LONG_MAX */
+#include "misc.h"
 
 #ifdef NRN_VERSION_GTEQ_8_2_0
 #define Vect IvocVect
-extern Object* ivoc_list_item(Object*, int); // should be part of API
+externc Object* ivoc_list_item(Object*, int); // should be part of API
 
 #if NRN_VERSION_EQ(8, 2, 0)
     // should be part of API

--- a/misc.h
+++ b/misc.h
@@ -1,0 +1,26 @@
+#include <stdint.h>
+
+#ifndef NRN_VERSION_GTEQ_8_2_0
+extern FILE* hoc_obj_file_arg(int narg);
+extern Object* ivoc_list_item(Object*, int);
+extern int hoc_is_tempobj_arg(int narg);
+char *gargstr();
+char** hoc_pgargstr();
+#else // TODO: Update nrn master & C++ PR
+#ifdef __cplusplus
+extern "C" {
+#endif
+Object* ivoc_list_item(Object*, int);
+#ifdef __cplusplus
+}
+#endif
+#endif
+
+int list_vector_px(Object *ob, int i, double** px);
+extern int list_vector_px2(Object *ob, int i, double** px, void** vv);
+extern int list_vector_px3(Object *ob, int i, double** px, void** vv);
+extern int list_vector_px4(Object *ob, int i, double** px, unsigned int n);
+extern void mcell_ran4_init(uint32_t idum);
+extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
+extern double *vector_newsize (IvocVect* vv, int n);
+//double *list_vector_resize(Object *ob, int i, int sz);

--- a/misc.h
+++ b/misc.h
@@ -14,14 +14,7 @@ extern char *gargstr();
 extern char** hoc_pgargstr();
 extern void mcell_ran4_init(uint32_t idum);
 extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
-extern double *vector_newsize (IvocVect* vv, int n);
-#else // >= 8.2.0
-#if NRN_VERSION_EQ(8, 2, 0)
-extern void mcell_ran4_init(uint32_t idum);
-extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
-#endif // == 8.2.0
-#endif // >= 8.2.0
-
+#endif
 
 extern int list_vector_px(Object *ob, int i, double** px);
 extern int list_vector_px2(Object *ob, int i, double** px, void** vv);

--- a/misc.h
+++ b/misc.h
@@ -1,5 +1,11 @@
 #include <stdint.h>
 
+#ifdef __cplusplus
+#define externc extern "C"
+#else
+#define externc extern
+#endif
+
 #ifndef NRN_VERSION_GTEQ_8_2_0
 extern FILE* hoc_obj_file_arg(int narg);
 extern Object* ivoc_list_item(Object*, int);

--- a/misc.h
+++ b/misc.h
@@ -1,11 +1,4 @@
 #include <stdint.h>
-
-#ifdef __cplusplus
-#define externc extern "C"
-#else
-#define externc extern
-#endif
-
 #ifndef NRN_VERSION_GTEQ_8_2_0
 extern FILE* hoc_obj_file_arg(int narg);
 extern Object* ivoc_list_item(Object*, int);

--- a/misc.h
+++ b/misc.h
@@ -4,23 +4,15 @@
 extern FILE* hoc_obj_file_arg(int narg);
 extern Object* ivoc_list_item(Object*, int);
 extern int hoc_is_tempobj_arg(int narg);
-char *gargstr();
-char** hoc_pgargstr();
-#else // TODO: Update nrn master & C++ PR
-#ifdef __cplusplus
-extern "C" {
-#endif
-Object* ivoc_list_item(Object*, int);
-#ifdef __cplusplus
-}
-#endif
-#endif
-
-int list_vector_px(Object *ob, int i, double** px);
-extern int list_vector_px2(Object *ob, int i, double** px, void** vv);
-extern int list_vector_px3(Object *ob, int i, double** px, void** vv);
-extern int list_vector_px4(Object *ob, int i, double** px, unsigned int n);
+extern char *gargstr();
+extern char** hoc_pgargstr();
 extern void mcell_ran4_init(uint32_t idum);
 extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
 extern double *vector_newsize (IvocVect* vv, int n);
-//double *list_vector_resize(Object *ob, int i, int sz);
+#endif
+
+extern int list_vector_px(Object *ob, int i, double** px);
+extern int list_vector_px2(Object *ob, int i, double** px, void** vv);
+extern int list_vector_px3(Object *ob, int i, double** px, void** vv);
+extern int list_vector_px4(Object *ob, int i, double** px, unsigned int n);
+extern double *vector_newsize (IvocVect* vv, int n);

--- a/misc.h
+++ b/misc.h
@@ -15,7 +15,13 @@ extern char** hoc_pgargstr();
 extern void mcell_ran4_init(uint32_t idum);
 extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
 extern double *vector_newsize (IvocVect* vv, int n);
-#endif
+#else // >= 8.2.0
+#if NRN_VERSION_EQ(8, 2, 0)
+extern void mcell_ran4_init(uint32_t idum);
+extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
+#endif // == 8.2.0
+#endif // >= 8.2.0
+
 
 extern int list_vector_px(Object *ob, int i, double** px);
 extern int list_vector_px2(Object *ob, int i, double** px, void** vv);

--- a/misc.mod
+++ b/misc.mod
@@ -48,6 +48,7 @@ VERBATIM
 #include <time.h>
 #include <stdio.h>
 #include <limits.h>
+#include "misc.h"
 extern int hoc_is_tempobj(int narg);
 ENDVERBATIM
 
@@ -58,7 +59,7 @@ VERBATIM
        errno else will get a nrnoc error.  Seems to be a problem even
        if I don't include <errno.h> */
 
-    char *gargstr(), *filename;
+    char *filename;
 
     filename = gargstr(1);
 
@@ -85,19 +86,18 @@ PROCEDURE sassign() {
 VERBATIM
     FILE *pipein;
     char string[BUFSIZ], **strname, *syscall;
-    char** hoc_pgargstr();
 
     strname = hoc_pgargstr(1);
     syscall = gargstr(2);
 
     if( !(pipein = popen(syscall, "r"))) {
         fprintf(stderr,"System call failed\n");
-        return; 
+        return 0;
     }
     
     if (fgets(string,BUFSIZ,pipein) == NULL) {
         fprintf(stderr,"System call did not return a string\n");
-        pclose(pipein); return;
+        pclose(pipein); return 0;
     }
 
     /*  assign_hoc_str(strname, string, 0); */
@@ -120,17 +120,17 @@ VERBATIM
 
     if ( !(outfile = fopen("dassign","w"))) {
         fprintf(stderr,"Can't open output file dassign\n");
-        return; 
+        return 0;
     }
 
     if( !(pipein = popen(syscall, "r"))) {
         fprintf(stderr,"System call failed\n");
-        fclose(outfile); return; 
+        fclose(outfile); return 0;
     }
     
     if (fscanf(pipein,"%lf",&num) != 1) {
         fprintf(stderr,"System call did not return a number\n");
-        fclose(outfile); pclose(pipein); return; 
+        fclose(outfile); pclose(pipein); return 0;
     }
 
     fprintf(outfile,"%s=%g\n",strname,num);
@@ -214,7 +214,7 @@ ENDVERBATIM
 FUNCTION hocgetc() {
 VERBATIM
 {	
-  FILE* f, *hoc_obj_file_arg();
+  FILE* f;
   f = hoc_obj_file_arg(1);
   _lhocgetc = (double)getc(f);
 }

--- a/misc.mod
+++ b/misc.mod
@@ -194,7 +194,7 @@ VERBATIM
   size_t x,y;
   x=(size_t)_lsz;
   pmlc=(char *)malloc(x);
-  printf("Did %ld: %x\n",x,pmlc);
+  printf("Did %ld: %p\n",x,pmlc);
   y=(unsigned int)_lsz-1;
   pmlc[y]=(char)97;
   printf("WRITE/READ 'a': "); 
@@ -224,7 +224,7 @@ ENDVERBATIM
 PROCEDURE pwd() {
   VERBATIM
   {char cwd[1000],cmd[1200];
-  getcwd(cwd, 1000);
+  assert(getcwd(cwd, 1000) == cwd);
   sprintf(cmd, "execute1(\"strdef cwd\")\n");         hoc_oc(cmd);
   sprintf(cmd, "execute1(\"cwd=\\\"%s\\\"\")\n",cwd); hoc_oc(cmd);
   }

--- a/readme.html
+++ b/readme.html
@@ -31,4 +31,8 @@ look at cell traces
 See headers of jitcon.mod and bstick_net.hoc for extensive (though
 alas not complete) commentary.
 
+Changelog
+---------
+2022-05: Updated MOD files to contain valid C++ and be compatible
+         with the upcoming versions 8.2 and 9.0 of NEURON.
 </pre></html

--- a/stats.mod
+++ b/stats.mod
@@ -38,7 +38,8 @@ VERBATIM
 #include <math.h>
 #include <limits.h> /* contains LONG_MAX */
 #include <float.h>
-#include <sys/time.h> 
+#include <sys/time.h>
+#include "misc.h"
 extern double BVBASE;
 extern double* hoc_pgetarg();
 Symbol *hoc_get_symbol();
@@ -48,26 +49,20 @@ extern double hoc_call_func(Symbol*, int narg);
 extern FILE* hoc_obj_file_arg(int narg);
 extern Object** hoc_objgetarg();
 extern void vector_resize();
-extern double *vector_newsize();
 extern int vector_instance_px();
 extern void* vector_arg();
 extern double* vector_vec();
 extern double hoc_epsilon;
-extern void mcell_ran4_init(unsigned int *idum);
-extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
 extern void set_seed();
 extern unsigned int *scrset();
 extern int ivoc_list_count(Object*);
 extern Object* ivoc_list_item(Object*, int);
-extern int list_vector_px2();
 extern int hoc_is_double_arg(int narg);
 extern Objectdata *hoc_objectdata;
 extern int openvec(int, double **);
 extern char* hoc_object_name(Object*);
 extern int nrn_mlh_gsort();
 extern int cmpdfn();
-int list_vector_px();
-int list_vector_resize();
 static void hxe() { hoc_execerror("",0); }
 unsigned int valseed;
 
@@ -364,8 +359,8 @@ static double hash (void* vv) {
       } else   {  xx.d=vvo[j][i]; }
       if (xx.i[0]==0) { xx.i[0]=xx.i[1]; xx.i[0]<<=4; } // high order bits may be 0
       if (xx.i[1]==0) { xx.i[1]=xx.i[0]; xx.i[1]<<=4; } // low order bits unlikely 0
-      mcell_ran4_init(&xx.i[1]);
-      mcell_ran4(&xx.i[0], &y, 1, big); // generate a pseudorand number based on these
+      mcell_ran4_init(xx.i[1]);
+      mcell_ran4((unsigned int*)&xx.i[0], &y, 1, big); // generate a pseudorand number based on these
       prod*=y;  // keep multiplying these out
     }
     if (! vfl) x[i]=prod; else return prod; // just return the 1 value
@@ -603,8 +598,8 @@ static double bin (void* vv) {
     if (lfl) ix[j]=jj+min;
   }
   maxsz=(max==1e9)?(int)(maxf/invl+1):(int)((max-min)/invl+1);
-  vector_resize(voi[0], maxsz);
-  if (lfl) vector_resize(voi[1], maxsz);
+  vector_resize((IvocVect*)voi[0], maxsz);
+  if (lfl) vector_resize((IvocVect*)voi[1], maxsz);
   return (double)maxsz;
 }
 ENDVERBATIM
@@ -781,7 +776,7 @@ FUNCTION gammln (xx) {
 FUNCTION betai(a,b,x) {
 VERBATIM {
   double bt;
-  double gammln(),betacf();
+  double gammln(double),betacf(double,double,double);
 
   if (_lx < 0.0 || _lx > 1.0) {printf("Bad x in routine BETAI\n"); hxe();}
   if (_lx == 0.0 || _lx == 1.0) bt=0.0;

--- a/vecst.mod
+++ b/vecst.mod
@@ -2412,11 +2412,11 @@ PROCEDURE install_vecst () {
 
 :* isojt(OB1,EXAMPLE_OBJ) return whether OB1 is an instance of EXAMPLE_OBJ
 FUNCTION isojt () {
-  VERBATIM {
+  VERBATIM
   Object *ob1, *ob2;
   ob1 = *hoc_objgetarg(1); ob2 = *hoc_objgetarg(2);
   if (!ob1) if (!ob2) return 1; else return 0;
- #ifdef __cplusplus
+#ifdef NRN_VERSION_GTEQ_8_2_0
   if (!ob2 || ob1->ctemplate != ob2->ctemplate) {
 #else
   if (!ob2 || ob1->template != ob2->template) {
@@ -2424,7 +2424,6 @@ FUNCTION isojt () {
     return 0;
   }
   return 1;
-  }
   ENDVERBATIM
 }
 

--- a/vecst.mod
+++ b/vecst.mod
@@ -114,7 +114,7 @@ extern double hoc_epsilon;
 extern double chkarg();
 extern void set_seed();
 extern int ivoc_list_count(Object*);
-externc Object* ivoc_list_item(Object*, int);
+extern Object* ivoc_list_item(Object*, int);
 extern int hoc_is_double_arg(int narg);
 extern char* hoc_object_name(Object*);
 extern int nrn_mlh_gsort();
@@ -1101,7 +1101,7 @@ static double keyind(void* vv) {
   int i, j, k, ni, nk, nv[VRRY], num;
   double *ind, *key, *vvo[VRRY];
   ni = vector_instance_px(vv, &ind); // vv is ind
-  for (i=0;ifarg(i);i++); i--; // drop back by one to get numarg()
+  for (i=0;ifarg(i);i++) {} i--; // drop back by one to get numarg()
   if (i>VRRY) hoc_execerror("ERR: keyind can only handle VRRY vectors", 0);
   num = i-1; // number of vectors to be picked apart 
   for (i=0;i<num;i++) { 

--- a/vecst.mod
+++ b/vecst.mod
@@ -95,12 +95,13 @@ PARAMETER {
 ASSIGNED { RES }
 
 VERBATIM
+#include "misc.h"
+#ifndef NRN_VERSION_GTEQ_8_2_0
 #include <stdlib.h>
 #include <math.h>
 #include <limits.h> // contains LONG_MAX 
 #include <sys/time.h> 
 #include <string.h>
-#include "misc.h"
 extern double* hoc_pgetarg();
 extern double hoc_call_func(Symbol*, int narg);
 extern FILE* hoc_obj_file_arg(int narg);
@@ -119,6 +120,7 @@ extern char* hoc_object_name(Object*);
 extern int nrn_mlh_gsort();
 char ** hoc_pgargstr();
 int ismono1();
+#endif
 int list_vector_resize (Object *ob, int i, int sz);
 int openvec (int arg, double **y);
 static double sc[6];
@@ -1149,7 +1151,7 @@ ENDVERBATIM
 : max is maximum diff to add to the tq db
 VERBATIM
 static double nearall (void* vv) {
-  register int	lo, hi, mid;
+  int	lo, hi, mid;
   int i, j, k, kk, nx, ny, minind, nv[4];
   Object *ob;
   void* vvl[4];

--- a/vecst.mod
+++ b/vecst.mod
@@ -2423,11 +2423,15 @@ FUNCTION isojt () {
   Object *ob1, *ob2;
   ob1 = *hoc_objgetarg(1); ob2 = *hoc_objgetarg(2);
   if (!ob1) if (!ob2) return 1; else return 0;
+#define ctemplate template
 #ifdef NRN_VERSION_GTEQ_8_2_0
-  if (!ob2 || ob1->ctemplate != ob2->ctemplate) {
-#else
-  if (!ob2 || ob1->template != ob2->template) {
+#if NRN_VERSION_GTEQ(9, 0, 0)
+#undef ctemplate
+#define ctemplate ctemplate
 #endif
+#endif
+  if (!ob2 || ob1->ctemplate != ob2->ctemplate) {
+#undef ctemplate
     return 0;
   }
   return 1;

--- a/vecst.mod
+++ b/vecst.mod
@@ -113,7 +113,7 @@ extern double hoc_epsilon;
 extern double chkarg();
 extern void set_seed();
 extern int ivoc_list_count(Object*);
-extern Object* ivoc_list_item(Object*, int);
+externc Object* ivoc_list_item(Object*, int);
 extern int hoc_is_double_arg(int narg);
 extern char* hoc_object_name(Object*);
 extern int nrn_mlh_gsort();
@@ -2416,7 +2416,7 @@ FUNCTION isojt () {
   Object *ob1, *ob2;
   ob1 = *hoc_objgetarg(1); ob2 = *hoc_objgetarg(2);
   if (!ob1) if (!ob2) return 1; else return 0;
-#ifdef NRN_VERSION_GTEQ_8_2_0
+#ifdef __cplusplus
   if (!ob2 || ob1->ctemplate != ob2->ctemplate) {
 #else
   if (!ob2 || ob1->template != ob2->template) {

--- a/vecst.mod
+++ b/vecst.mod
@@ -2421,7 +2421,7 @@ FUNCTION isojt () {
   Object *ob1, *ob2;
   ob1 = *hoc_objgetarg(1); ob2 = *hoc_objgetarg(2);
   if (!ob1) if (!ob2) return 1; else return 0;
-#ifdef __cplusplus
+#ifdef NRN_VERSION_GTEQ_8_2_0
   if (!ob2 || ob1->ctemplate != ob2->ctemplate) {
 #else
   if (!ob2 || ob1->template != ob2->template) {

--- a/vecst.mod
+++ b/vecst.mod
@@ -100,8 +100,8 @@ VERBATIM
 #include <limits.h> // contains LONG_MAX 
 #include <sys/time.h> 
 #include <string.h>
+#include "misc.h"
 extern double* hoc_pgetarg();
-extern double* vector_newsize(); 
 extern double hoc_call_func(Symbol*, int narg);
 extern FILE* hoc_obj_file_arg(int narg);
 extern Object** hoc_objgetarg();
@@ -117,15 +117,10 @@ extern Object* ivoc_list_item(Object*, int);
 extern int hoc_is_double_arg(int narg);
 extern char* hoc_object_name(Object*);
 extern int nrn_mlh_gsort();
-extern double mcell_ran4(unsigned int* idum,double* ran_vec,unsigned int n,double range);
-extern void mcell_ran4_init(unsigned int *idum);
 char ** hoc_pgargstr();
-double *vector_newsize(); 
 int ismono1();
-int list_vector_px();
-int list_vector_px2();
-int list_vector_resize();
-int openvec();
+int list_vector_resize (Object *ob, int i, int sz);
+int openvec (int arg, double **y);
 static double sc[6];
 static void hxe() { hoc_execerror("",0); }
 static void hxf(void *ptr) { free(ptr); hoc_execerror("",0); }
@@ -176,7 +171,7 @@ VERBATIM
 static double ident (void* vv) {
   int nx,bsz; double* x;
   nx = vector_instance_px(vv, &x);
-  bsz=vector_buffer_size(vv);
+  bsz=vector_buffer_size((IvocVect*)vv);
   printf("Obj*%x Dbl*%x Size: %d Bufsize: %d\n",vv,x,nx,bsz);
   return (double)nx;
 }
@@ -221,7 +216,7 @@ static double circ (void* vv) {
     rad=sqrt((x0-x1)*(x0-x1) + (y0-y1)*(y0-y1));
     lnew=*getarg(6); // resize the vectors
   } else if (ifarg(5)) lnew=*getarg(5); // resize the vectors
-  if (lnew) { nx=lnew; x=vector_newsize(vv,nx); y=vector_newsize(vector_arg(1),ny=nx); }
+  if (lnew) { nx=lnew; x=vector_newsize((IvocVect*)vv,nx); y=vector_newsize(vector_arg(1),ny=nx); }
   for (i=0,theta=0; i<nx; theta+=2*M_PI/(nx-1),i++) {
     x[i]=y0+rad*sin(theta); y[i]=x0+rad*cos(theta); 
   }
@@ -325,11 +320,11 @@ static double findx (void* vv) {
   nx=av[0]; // size of source vecs
   for (i=0;i<num;i++) { 
     bv[i]=list_vector_px2(ob2, i, &bvo[i], &vv); // dest vectors 
-    if (vector_buffer_size(vv)<ni) { 
-      printf("findx ****ERRD**** arg#%d need:%d sz:%d\n",num+i+1,ni,vector_buffer_size(vv));
+    if (vector_buffer_size((IvocVect*)vv)<ni) {
+      printf("findx ****ERRD**** arg#%d need:%d sz:%d\n",num+i+1,ni,vector_buffer_size((IvocVect*)vv));
       hoc_execerror("Destination vector with insufficient size: ", 0); 
     } else {
-      vector_resize(vv, ni);
+      vector_resize((IvocVect*)vv, ni);
     }
   }
   if (ni>scrsz) { 
@@ -509,7 +504,7 @@ static double slct (void* vv) {
       if (flag==1) break;
     } 
   }
-  vector_resize(vv, k);
+  vector_resize((IvocVect*)vv, k);
   return (double)k;
 }
 ENDVERBATIM
@@ -596,7 +591,7 @@ static double slor (void* vv) {
     }
     if (fl) ind[k++]=j; // all equal
   }
-  vector_resize(vv, k);
+  vector_resize((IvocVect*)vv, k);
   return (double)k;
 }
 ENDVERBATIM
@@ -606,7 +601,7 @@ VERBATIM
 static double iwr(void* vv) {
   int i, j, nx;
   double *x;
-  FILE* f, *hoc_obj_file_arg();
+  FILE* f;
   f = hoc_obj_file_arg(1);
   nx = vector_instance_px(vv, &x);
   scrset(nx);
@@ -622,7 +617,7 @@ VERBATIM
 static double ird(void* vv) {
   int i, j, nx, n;
   double *x;
-  FILE* f, *hoc_obj_file_arg();
+  FILE* f;
   f = hoc_obj_file_arg(1);
   nx = vector_instance_px(vv, &x);
   fread(&n,sizeof(int),1,f);  // size
@@ -632,9 +627,9 @@ static double ird(void* vv) {
     scr=(unsigned int *)ecalloc(scrsz, sizeof(int));
   }
   if (n!=nx) { 
-    nx=vector_buffer_size(vv);
+    nx=vector_buffer_size((IvocVect*)vv);
     if (n<=nx) {
-      vector_resize(vv, n); nx=n; 
+      vector_resize((IvocVect*)vv, n); nx=n;
     } else {
       printf("%d > %d :: ",n,nx);
       hoc_execerror("Vector max capacity too small for ird ", 0);
@@ -651,19 +646,19 @@ VERBATIM
 static double fread2(void* vv) {
   int i, j, nx, n, type, maxsz;
   double *x;
-  FILE* fp, *hoc_obj_file_arg();
+  FILE* fp;
   BYTEHEADER
 
   fp = hoc_obj_file_arg(1);
   nx = vector_instance_px(vv, &x);
-  maxsz=vector_buffer_size(vv);
+  maxsz=vector_buffer_size((IvocVect*)vv);
   n = (int)*getarg(2);
   type = (int)*getarg(3);
   if (n>maxsz) {
     printf("%d > %d :: ",n,maxsz);
     hoc_execerror("Vector max capacity too small for fread2 ", 0);
   } else {
-    vector_resize(vv, n);
+    vector_resize((IvocVect*)vv, n);
   }
   if (type==6 || type==16) {         // unsigned ints
     unsigned int *xs;
@@ -690,6 +685,7 @@ static double fread2(void* vv) {
     }
     free((char *)xf);    
   } else hoc_execerror("Type unsupported in fread2 ", 0);
+  return 0;
 }
 ENDVERBATIM
 
@@ -700,15 +696,15 @@ static double insct (void* vv) {
 	int i, j, k, nx, nv1, nv2, maxsz;
 	double *x, *v1, *v2;
 	nx = vector_instance_px(vv, &x);
-        maxsz=vector_buffer_size(vv);
-        vector_resize(vv, maxsz);
+        maxsz=vector_buffer_size((IvocVect*)vv);
+        vector_resize((IvocVect*)vv, maxsz);
 	nv1 = vector_arg_px(1, &v1);
 	nv2 = vector_arg_px(2, &v2);
         for (i=0,k=0;i<nv1;i++) for (j=0;j<nv2;j++) if (v1[i]==v2[j]) {
           if (k<maxsz) { x[k++]=v1[i]; } else {k++;}}  // v1[i] found in both vectors 
         if (k>maxsz) { 
           printf("\tinsct WARNING: ran out of room: %d<%d\n",maxsz,k);
-        } else { vector_resize(vv, k); }
+        } else { vector_resize((IvocVect*)vv, k); }
 	return (double)k;
 }
 ENDVERBATIM
@@ -722,6 +718,7 @@ static double vfill (void* vv) {
 	nx = vector_instance_px(vv, &x);
 	nv1 = vector_arg_px(1, &v1);
         for (i=0;i<nx;i++) x[i]=v1[i%nv1];
+  return 0;
 }
 ENDVERBATIM
 
@@ -732,8 +729,8 @@ static double cull (void* vv) {
 	int i, j, k, nx, nv1, nv2, maxsz, flag;
 	double *x, *v1, *v2;
 	nx = vector_instance_px(vv, &x);
-        maxsz=vector_buffer_size(vv);
-        vector_resize(vv, maxsz);
+        maxsz=vector_buffer_size((IvocVect*)vv);
+        vector_resize((IvocVect*)vv, maxsz);
 	nv1 = vector_arg_px(1, &v1);
 	nv2 = vector_arg_px(2, &v2);
         for (i=0,k=0;i<nv1;i++) {
@@ -743,7 +740,7 @@ static double cull (void* vv) {
         }
         if (k>maxsz) { 
           printf("\tcull WARNING: ran out of room: %d<%d\n",maxsz,k);
-        } else { vector_resize(vv, k); }
+        } else { vector_resize((IvocVect*)vv, k); }
 	return (double)k;
 }
 ENDVERBATIM
@@ -759,11 +756,11 @@ static double redundout (void* vv) {
   if (ifarg(2)) indflag=(int)*getarg(2); else indflag=0; 
   if (ifarg(3)) { cntflag=1; 
     ncntr = vector_arg_px(3, &cntr);  vc=vector_arg(3); 
-    ncntr = vector_buffer_size(vc);   vector_resize(vc, ncntr);
+    ncntr = vector_buffer_size((IvocVect*)vc);   vector_resize((IvocVect*)vc, ncntr);
     for (i=0;i<ncntr;i++) cntr[i]=1.; // will be at least 1 of each #
   } else cntflag=0;
   nx = vector_instance_px(vv, &x);
-  maxsz=vector_buffer_size(vv);  vector_resize(vv, maxsz);
+  maxsz=vector_buffer_size((IvocVect*)vv);  vector_resize((IvocVect*)vv, maxsz);
   nv1 = vector_arg_px(1, &v1);
   val=v1[0]; x[0]=(indflag?0:val);
   if (cntflag) {
@@ -775,10 +772,10 @@ static double redundout (void* vv) {
   }
   if (j>=maxsz) { 
     printf("\tredundout WARNING: ran out of room: %d<needed\n",maxsz);
-  } else { vector_resize(vv, j); }
+  } else { vector_resize((IvocVect*)vv, j); }
   if (cntflag) if (j>=ncntr) { 
     printf("\tredundout WARNING: cntr ran out of room: %d<needed\n",ncntr);
-  } else { vector_resize(vc, j); }
+  } else { vector_resize((IvocVect*)vc, j); }
   return (double)j;
 }
 ENDVERBATIM
@@ -804,8 +801,8 @@ static double mredundout (void* vv) {
     ob2 = *hoc_objgetarg(3);
     numb = ivoc_list_count(ob2);
   } else numb=0;
-  maxsz=vector_buffer_size(vv);
-  if (indflag) vector_resize(vv, maxsz); // else vector is not used
+  maxsz=vector_buffer_size((IvocVect*)vv);
+  if (indflag) vector_resize((IvocVect*)vv, maxsz); // else vector is not used
   num = ivoc_list_count(ob);
   if (num>VRRY) hoc_execerror("mredundout ****ERRA****: can only handle VRRY vectors", 0);
   for (i=0;i<num;i++) { 
@@ -837,7 +834,7 @@ static double mredundout (void* vv) {
   if (indflag) { // just fill ind with indices of the repeats
     if (k>maxsz){printf("mredundout****ERRE**** vec overflow %d>%d\n",k,maxsz);hxe();}
     for (i=0;i<k;i++) x[i]=(double)scr[i];
-    vector_resize(vv, k);
+    vector_resize((IvocVect*)vv, k);
   } else { // remove all the repeat rows
     if (k == 0) return (double)k;
     for (i=0,p=scr[0]; i<k-1; i++) { // iter thru the inds to remove
@@ -850,8 +847,8 @@ static double mredundout (void* vv) {
       for (j=0;j<num; j++) avo[j][p]=avo[j][m]; 
       for (j=0;j<numb;j++) bvo[j][p]=bvo[j][m]; 
     }
-    for (j=0;j<num; j++) vector_resize(vva[j], ns-k); // resize all the vectors
-    for (j=0;j<numb;j++) vector_resize(vvb[j], ns-k);
+    for (j=0;j<num; j++) vector_resize((IvocVect*)vva[j], ns-k); // resize all the vectors
+    for (j=0;j<numb;j++) vector_resize((IvocVect*)vvb[j], ns-k);
   }
   return (double)k;
 }
@@ -905,6 +902,7 @@ static double vscl(double *x, double n) {
   r=max-min;  // range
   sf = (b-a)/r; // scaling factor
   for (i=0;i<n;i++) x[i]=(x[i]-min)*sf+a;
+  return 0;
 }
 ENDVERBATIM
 
@@ -918,6 +916,7 @@ static double scl(void* vv) {
   if (nx!=nsrc) { hoc_execerror("scl:Vectors not same size: ", 0); }
   for (i=0;i<nx;i++) x[i]=src[i];
   vscl(x,nx);
+  return 0;
 }
 ENDVERBATIM
 
@@ -940,6 +939,7 @@ static double sccvlv(void* vv) {
     vscl(tmp,j-1);
     for (k=0;k<j;k++) x[i]+=filt[k]*tmp[k];
   }
+  return 0;
 }
 ENDVERBATIM
 
@@ -996,6 +996,7 @@ static double cvlv (void* vv) {
       if (k>0 && k<nsrc-1) x[i]+=filt[j]*src[k];
     }
   }
+  return 0;
 }
 ENDVERBATIM
 
@@ -1080,7 +1081,7 @@ static double nind(void* vv) {
           }
           for (k=last+1;k<nx;k++,m++) { x[m]=vvo[j][k]; }
           for (i=0;i<c;i++) vvo[j][i]=x[i];   
-          vv=vector_arg(j+2); vector_resize(vv, c);
+          vv=vector_arg(j+2); vector_resize((IvocVect*)vv, c);
         }
 	return c;
 }
@@ -1115,7 +1116,7 @@ static double keyind(void* vv) {
     }
     if (i==nk) ind[k++]=j; // all equal
   }
-  vector_resize(vv, k);
+  vector_resize((IvocVect*)vv, k);
   return (double)k;
 }
 ENDVERBATIM
@@ -1147,7 +1148,7 @@ static double nearall (void* vv) {
   int i, j, k, kk, nx, ny, minind, nv[4];
   Object *ob;
   void* vvl[4];
-  double *x, *y, *vvo[4], targ, dist, new, max, tmp;
+  double *x, *y, *vvo[4], targ, dist, newval, max, tmp;
   nx = vector_instance_px(vv, &x);
   max = *getarg(1);
   ny = vector_arg_px(2, &y);
@@ -1165,8 +1166,8 @@ static double nearall (void* vv) {
     }
     dist=fabs(x[mid]-targ); minind=mid;
     for (i=-1;i<=1;i+=2) { kk=mid+i; // check the flanking values
-      if (kk>0 && kk<nx && (new=fabs(x[kk]-targ))<dist) { 
-        dist=new;
+      if (kk>0 && kk<nx && (newval=fabs(x[kk]-targ))<dist) {
+        dist=newval;
         minind=kk;
       }
     }
@@ -1195,7 +1196,7 @@ static double nearall (void* vv) {
     vvo[2][i]=vvo[2][scr[i]];
     vvo[3][i]=vvo[3][scr[i]];
   }
-  for (i=0;i<4;i++) vector_resize(vvl[i],kk);
+  for (i=0;i<4;i++) vector_resize((IvocVect*)vvl[i],kk);
   return (double)kk;
 }
 ENDVERBATIM
@@ -1204,14 +1205,14 @@ ENDVERBATIM
 VERBATIM
 static double nearest (void* vv) {
   int i, nx, minind, flag=0;
-  double *x, targ, dist, new, *to;
+  double *x, targ, dist, newval, *to;
   nx = vector_instance_px(vv, &x);
   targ = *getarg(1);
   if (ifarg(3)) flag = (int)*getarg(3);
   dist = 1e9;
-  for (i=0; i<nx; i++) if ((new=fabs(x[i]-targ))<dist) { 
-    if (flag && new==0) continue; // flag signals to not pick self
-    dist=new;
+  for (i=0; i<nx; i++) if ((newval=fabs(x[i]-targ))<dist) {
+    if (flag && newval==0) continue; // flag signals to not pick self
+    dist=newval;
     minind=i;
   }
   if (ifarg(2)) *(hoc_pgetarg(2)) = dist;
@@ -1242,10 +1243,10 @@ static double samp (void* vv) {
   nx = vector_instance_px(vv, &x); // dest
   iOrigSz = vector_arg_px(1, &y); // source
   dNewSz = *getarg(2);  // new size
-  maxsz=vector_buffer_size(vv); 
+  maxsz=vector_buffer_size((IvocVect*)vv);
   iNewSz = (int)dNewSz;
   if (iNewSz>maxsz) {printf("VECST samp ERRA: dest vec too small: %d %d\n",iNewSz,maxsz); hxe();}
-  vector_resize(vv,iNewSz);
+  vector_resize((IvocVect*)vv,iNewSz);
 
   scale = (double) iOrigSz / (double) iNewSz;
   for(i=0;i<iNewSz;i++){
@@ -1315,6 +1316,7 @@ static double bpeval(void* vv) {
   } else {
     for (i=0;i<n;i++) vo[i]=outp[i]*(1.-1.*outp[i])*del[i];
   }
+  return 0;
 }
 ENDVERBATIM
  
@@ -1384,7 +1386,7 @@ static double slone (void* vv) {
   int i, j, n, ni, nsrc, maxsz;
   double *x, *src, val, max, min;
   n = vector_instance_px(vv, &x);
-  maxsz=vector_buffer_size(vv);  vector_resize(vv, maxsz);
+  maxsz=vector_buffer_size((IvocVect*)vv);  vector_resize((IvocVect*)vv, maxsz);
   nsrc = vector_arg_px(1, &src);
   val = *getarg(2);
   if (ifarg(3)) ni=(int)*getarg(3); else {
@@ -1400,7 +1402,7 @@ static double slone (void* vv) {
   }
   for (j=0;src[i]==val && j<maxsz && i<nsrc;i++,j++) x[j]=i;
   if (j==maxsz) printf("vecst slone WARN: OOR %d %d\n",j,maxsz);
-  vector_resize(vv, j);
+  vector_resize((IvocVect*)vv, j);
   return (double)(i-1);
 }
 ENDVERBATIM
@@ -1424,8 +1426,8 @@ static double xing (void* vv) {
   } else if (ifarg(2)) {
     th = *getarg(2);
   } else th=0.0; // default threshold
-  maxsz=vector_buffer_size(vv);
-  vector_resize(vv, maxsz);
+  maxsz=vector_buffer_size((IvocVect*)vv);
+  vector_resize((IvocVect*)vv, maxsz);
   if (tvf && nsrc!=ntvec) hoc_execerror("v.xing: vectors not all same size", 0);
   for (i=0,f=0,j=0; i<nsrc; i++) {
     if (src[i]>th) { // ? passing thresh 
@@ -1447,7 +1449,7 @@ static double xing (void* vv) {
       if (f==1) { f=0; } // just passed going down 
     }
   }
-  vector_resize(vv, j);
+  vector_resize((IvocVect*)vv, j);
   return (double)i;
 }
 ENDVERBATIM
@@ -1463,13 +1465,13 @@ static double snap (void* vv) {
   nsrc = vector_arg_px(1, &src);
   ntvec = vector_arg_px(2, &tvec);
   dtt = *getarg(3);
-  maxsz=vector_buffer_size(vv);
+  maxsz=vector_buffer_size((IvocVect*)vv);
   tstop = tvec[nsrc-1];
   size=(int)tstop/dtt;
   if (size>maxsz) { 
     printf("%g > %g\n",size,maxsz);
     hoc_execerror("v.snap: insufficient room in dest", 0); }
-  vector_resize(vv, size);
+  vector_resize((IvocVect*)vv, size);
   if (nsrc!=ntvec) hoc_execerror("v.snap: src and tvec not same size", 0);
   for (tt=0,i=0;i<size && tt<=tvec[0];i++,tt+=dtt) dest[i]=src[0];
   for (j=1, i--, tt-=dtt; i<size; i++, val=-1e9, tt+=dtt) {
@@ -1596,7 +1598,7 @@ static double lcat(void* vv) {
   double *x, *fr; 
   void *vw;
   n = vector_instance_px(vv, &x);
-  vector_resize(vv,maxsz=vector_buffer_size(vv)); // open it up fully
+  vector_resize((IvocVect*)vv,maxsz=vector_buffer_size((IvocVect*)vv)); // open it up fully
   ob1 = *hoc_objgetarg(1);
   lc = ivoc_list_count(ob1);
   for (i=0,j=0;i<lc && j<maxsz;i++) {
@@ -1604,7 +1606,7 @@ static double lcat(void* vv) {
     for (k=0;k<cap && j<maxsz;k++,j++) x[j]=fr[k];
   }
   if (i<lc || k<cap) printf("vecst lcat WARN: not all vecs copied\n");
-  vector_resize(vv,j);
+  vector_resize((IvocVect*)vv,j);
   return (double)j;
 }
 ENDVERBATIM
@@ -1652,9 +1654,9 @@ static double uncode (void* vv) {
   } else if (!ifarg(2)) { // numarg()==1
     if (hoc_is_double_arg(1)) {
       val = *getarg(1);
-      if (vector_buffer_size(vv)<5) {
+      if (vector_buffer_size((IvocVect*)vv)<5) {
         hoc_execerror("uncode ****ERRA****: vector too small to resize(5)", 0);}
-      vector_resize(vv,5);
+      vector_resize((IvocVect*)vv,5);
       for (i=1;i<=5;i++) UNCODE(val,i,x[i-1])
       return x[0];
     } else {
@@ -1709,8 +1711,8 @@ int list_vector_px (Object *ob, int i, double** px) {
   int sz;
   obv = ivoc_list_item(ob, i);
   if (! ISVEC(obv)) return -1;
-  sz = vector_capacity(obv->u.this_pointer);
-  *px = vector_vec(obv->u.this_pointer);
+  sz = vector_capacity((IvocVect*)obv->u.this_pointer);
+  *px = vector_vec((IvocVect*)obv->u.this_pointer);
   return sz;
 }
 
@@ -1721,8 +1723,8 @@ int list_vector_px2 (Object *ob, int i, double** px, void** vv) {
   int sz;
   obv = ivoc_list_item(ob, i);
   if (! ISVEC(obv)) return -1;
-  sz = vector_capacity(obv->u.this_pointer);
-  *px = vector_vec(obv->u.this_pointer);
+  sz = vector_capacity((IvocVect*)obv->u.this_pointer);
+  *px = vector_vec((IvocVect*)obv->u.this_pointer);
   *vv = (void*) obv->u.this_pointer;
   return sz;
 }
@@ -1735,10 +1737,10 @@ int list_vector_px3 (Object *ob, int i, double** px, void** vv) {
   int sz;
   obv = ivoc_list_item(ob, i);
   if (! ISVEC(obv)) return -1;
-  sz = vector_buffer_size(obv->u.this_pointer);
-  *px = vector_vec(obv->u.this_pointer);
+  sz = vector_buffer_size((IvocVect*)obv->u.this_pointer);
+  *px = vector_vec((IvocVect*)obv->u.this_pointer);
   *vv = (void*) obv->u.this_pointer;
-  vector_resize(*vv,sz);
+  vector_resize((IvocVect*)*vv,sz);
   return sz;
 }
 
@@ -1750,14 +1752,14 @@ int list_vector_px4 (Object *ob, int i, double** px, unsigned int n) {
   int sz;
   obv = ivoc_list_item(ob, i);
   if (! ISVEC(obv)) return -1;
-  sz = vector_buffer_size(obv->u.this_pointer);
-  *px = vector_vec(obv->u.this_pointer);
+  sz = vector_buffer_size((IvocVect*)obv->u.this_pointer);
+  *px = vector_vec((IvocVect*)obv->u.this_pointer);
   vv = (void*) obv->u.this_pointer;
   if (n>sz) {
     printf("List vector WARNING: unable to resize to %d requested (%d)\n",n,sz);
-    vector_resize(vv,sz);
+    vector_resize((IvocVect*)vv,sz);
     return 0;
-  } else vector_resize(vv,n);
+  } else vector_resize((IvocVect*)vv,n);
   return 1;
 }
 
@@ -1767,13 +1769,13 @@ int list_vector_resize (Object *ob, int i, int sz) {
   int maxsz;
   obv = ivoc_list_item(ob, i);
   if (! ISVEC(obv)) return -1;
-  maxsz = vector_buffer_size(obv->u.this_pointer);
+  maxsz = vector_buffer_size((IvocVect*)obv->u.this_pointer);
   if (sz>maxsz) {
     printf("max:%d request:%d ",maxsz,sz);
     hoc_execerror("Can't grow vector in list_vector_resize ", 0);
     return -1;
   }
-  vector_resize(obv->u.this_pointer,sz);
+  vector_resize((IvocVect*)obv->u.this_pointer,sz);
   return sz;
 }
 ENDVERBATIM
@@ -1870,11 +1872,11 @@ static double uniq (void* vv) {
       ob= *hoc_objgetarg(1);
       ny=list_vector_px3(ob, 0, &y, &voi[0]);
       nz=list_vector_px3(ob,1,&z,&voi[1]);
-      if (nz==0) z=vector_newsize(voi[1],nz=100);
+      if (nz==0) z=vector_newsize((IvocVect*)voi[1],nz=100);
     } else {
       voi[0]=vector_arg(1);   // save vector pointer
     }
-    if (ny==0) y=vector_newsize(voi[0],ny=100);
+    if (ny==0) y=vector_newsize((IvocVect*)voi[0],ny=100);
   }
   if (ifarg(2)) {
     if (hoc_is_double_arg(2)) { 
@@ -1884,33 +1886,33 @@ static double uniq (void* vv) {
     } else {
       if (nz>0) {printf("ERROR: uniq(list,vec)\n"); hxe();}
       voi[1]=vector_arg(2);
-      if ((nz=openvec(2,&z))==0) z=vector_newsize(voi[1],nz=100);
+      if ((nz=openvec(2,&z))==0) z=vector_newsize((IvocVect*)voi[1],nz=100);
     }
   }
   if (n==0) return 0.;
   scrset(n);
   for (i=0;i<n;i++) scr[i]=i;
-  nrn_mlh_gsort(x, scr, n, cmpdfn);
+  nrn_mlh_gsort(x, (int*)scr, n, cmpdfn);
   if (ny) y[0]=x[scr[0]]; 
   if (nz>0) z[0]=1.;
   for (i=1, lastx=x[scr[0]], cnt=1; i<n; i++) {
     if (x[scr[i]]>lastx+hoc_epsilon) {
       if (ny) { 
-        if (cnt>=ny) y=vector_newsize(voi[0],ny*=3);
+        if (cnt>=ny) y=vector_newsize((IvocVect*)voi[0],ny*=3);
         y[cnt]=x[scr[i]]; 
       }
       if (nz>0) {
-        if (cnt>=nz) z=vector_newsize(voi[1],nz*=3);
+        if (cnt>=nz) z=vector_newsize((IvocVect*)voi[1],nz*=3);
         z[cnt]=1.;
       }
       cnt++;
       lastx=x[scr[i]];
     } else if (nz>0) z[cnt-1]++;
   }
-  if (ny) vector_resize(voi[0], cnt);
-  if (nz>0) vector_resize(voi[1], cnt);
+  if (ny) vector_resize((IvocVect*)voi[0], cnt);
+  if (nz>0) vector_resize((IvocVect*)voi[1], cnt);
   if (flag) { // refill z with the unique values in proper order
-    z=vector_newsize(voi[1], cnt);
+    z=vector_newsize((IvocVect*)voi[1], cnt);
     for (i=0;i<n;i++) ix[i]=1;
     for (i=0,j=0;i<n;i++) {
       lt=0; rt=cnt-1; res=-1; num=x[i];
@@ -1973,14 +1975,14 @@ int openvec (int arg, double **y) {
   if (! ISVEC(ob)) return -1;
   vector_arg_px(arg, y);
   vv=vector_arg(arg);
-  max=vector_buffer_size(vv);
-  vector_resize(vv, max);
+  max=vector_buffer_size((IvocVect*)vv);
+  vector_resize((IvocVect*)vv, max);
   if (max==0) printf("openvec(): 0 size vec\n");
   return max;
 }
 
 // vector_newsize() will also increase size of vector
-double *vector_newsize (void* vv, int n) {
+double *vector_newsize (IvocVect* vv, int n) {
   vector_resize(vv,n);
   return vector_vec(vv);
 }
@@ -2004,7 +2006,7 @@ static double pop(void* vv) {
   double *x;
   n = vector_instance_px(vv, &x);
   if (n==0) {printf("vec.pop ERR: empty vec\n");hxe();}
-  vector_resize(vv,n-1);
+  vector_resize((IvocVect*)vv,n-1);
   return x[n-1];
 }
 ENDVERBATIM
@@ -2037,9 +2039,9 @@ static double smgs (void* vv) {
 
   points = (int)((high-low)/step+hoc_epsilon);
   if (nsum!=points) { 
-    maxsz=vector_buffer_size(vv);
+    maxsz=vector_buffer_size((IvocVect*)vv);
     if (points<=maxsz) {
-      nsum=points;  vector_resize(vv, nsum); 
+      nsum=points;  vector_resize((IvocVect*)vv, nsum);
     } else {
       printf("%d > %d :: ",points,maxsz);
       hoc_execerror("Vector max capacity too small in smgs ", 0);
@@ -2087,9 +2089,9 @@ static double smsy (void* vv) {
 
   points=(int)(tstop/dtt+hoc_epsilon);
   if (nsum!=points) { 
-    maxsz=vector_buffer_size(vv);
+    maxsz=vector_buffer_size((IvocVect*)vv);
     if (points<=maxsz) {
-      vector_resize(vv, points); points=nsum; 
+      vector_resize((IvocVect*)vv, points); points=nsum;
     } else {
       printf("%d > %d :: ",points,maxsz);
       hoc_execerror("Dest vector too small in smsy ", 0);
@@ -2112,12 +2114,12 @@ static double vrdh (void* vv) {
   FILE* f;
 
   num = vector_instance_px(vv, &x);
-  maxsz=vector_buffer_size(vv);
+  maxsz=vector_buffer_size((IvocVect*)vv);
   f =     hoc_obj_file_arg(1);
   num = (int)*getarg(2); // number of vectors to look for
 
   if (maxsz<2*num){printf("vrdh ERR0 need %d room in vec\n",2*num);hxe();}
-  vector_resize(vv, 2*num);
+  vector_resize((IvocVect*)vv, 2*num);
 
   for (i=0;i<num;i++) { 
     fread(&n,sizeof(int),2,f); // n[1] is type
@@ -2298,7 +2300,7 @@ static double rdfile (void* vv) {
         k+=vsz;
       } else { 
         for (j=0;j<vsz;j++) vvo[cnt][j]=(double)xf[j];
-        vector_resize(vnq[cnt],vsz);
+        vector_resize((IvocVect*)vnq[cnt],vsz);
       }
       i+=(vsz*sizeof(float));
     } else if (ty==4) { // double is just a memcpy
@@ -2308,7 +2310,7 @@ static double rdfile (void* vv) {
         k+=vsz;
       } else {
         memcpy((void*)(&vvo[cnt][0]),xv,(size_t)(vsz*sizeof(double)));
-        vector_resize(vnq[cnt],vsz);
+        vector_resize((IvocVect*)vnq[cnt],vsz);
       }
       i+=(vsz*sizeof(double));
     } else if (ty==2) { // short must be shifted and scaled
@@ -2320,12 +2322,12 @@ static double rdfile (void* vv) {
         k+=vsz;
       } else { 
         for (j=0;j<vsz;j++) vvo[cnt][j]=((double)xus[j])/sf[0] + sf[1];
-        vector_resize(vnq[cnt],vsz);
+        vector_resize((IvocVect*)vnq[cnt],vsz);
       }
       i+=(vsz*sizeof(short));
     } else printf("rdfile() type %d not implemented\n",ty);
   }
-  if (vflag) vector_resize(vector_arg(2), k);
+  if (vflag) vector_resize((IvocVect*)vector_arg(2), k);
   if (scrsz>1e7) { free(scr); scr=(unsigned int *)NULL; scrsz=0; }
   return (double)num;
 }
@@ -2414,7 +2416,11 @@ FUNCTION isojt () {
   Object *ob1, *ob2;
   ob1 = *hoc_objgetarg(1); ob2 = *hoc_objgetarg(2);
   if (!ob1) if (!ob2) return 1; else return 0;
+ #ifdef __cplusplus
+  if (!ob2 || ob1->ctemplate != ob2->ctemplate) {
+#else
   if (!ob2 || ob1->template != ob2->template) {
+#endif
     return 0;
   }
   return 1;


### PR DESCRIPTION
jitcon.mod compiles for 8.0.0, 8.2.0, and 9.0.0
In particular note:
```
    NEURON API for jitcon.mod separated into < == > 8.2.0 sections.
     It would be possible to simplify that with
      #ifdef NRN_VERSION_GTEQ_8_2_0
      #define Vect IvocVect
      #else
      #define Vect void
      #endif
    and always get the explicit NEURON API prototypes.
```